### PR TITLE
Potentially fixes BTree language server error

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project>
+
+	<!-- _________________________ Library Patch _________________________ -->
+	<!--Enable behavior tree debug features (required for BTreeInspector and BTreeVisualizer)-->
+    <!--This enables addChangeListener on BTExecutor and dirty field on BTContext-->
+    <!--This fixes an inconsistent language server error on projects with bitdecaybtree added-->
+    <haxedef name="BT_DEBUG" />
+
 	<!-- _________________________ Application Settings _________________________ -->
 
 	<app title="HaxeflixelTemplate" main="Main" version="0.0.1" company="BitDecay Games" />

--- a/haxelib.deps
+++ b/haxelib.deps
@@ -30,5 +30,5 @@ json2object 3.11.0
 # audio deps
 flixel-fmod git https://github.com/MondayHopscotch/flixel-fmod.git
 # intentionally get haxefmod second so that flixel-fmod doesn't override it
-haxefmod git https://github.com/Tanz0rz/haxe-fmod.git 1.1.0-beta
+haxefmod git https://github.com/Tanz0rz/haxe-fmod.git 1.1.2-beta
 


### PR DESCRIPTION
There is a long-standing language server error that comes from within the BTree dependency. This may fix it. If it does not, I think we should comment out the dependency and just pull it in when we actually need it.